### PR TITLE
GitHub action for running benchmarks

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -1,0 +1,52 @@
+name: Build LoAT Base Image
+
+on:
+  # Automatically run this action on every push to `master` but only
+  # if there are changes in the image directory. The image does not 
+  # depend on any LoAT sources, so re-build is only necessary when 
+  # the configuration of the image itself changes.
+  push:
+    branches: 
+      - master
+    paths:
+      - 'docker/loat-base-image/**'
+
+  # Also allow this action to be triggered manually via a button in 
+  # the GitHub UI.
+  workflow_dispatch:
+
+# Config mainly copied from here: 
+# https://github.com/marketplace/actions/build-and-push-docker-images
+jobs:
+  build-base-image:
+    runs-on: ubuntu-latest
+    steps:
+      # not sure what this step is good for but is was part of the
+      # example config:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          # Push resulting image to Docker Hub so it can be used on any machine or other
+          # or other pipelines:
+          push: true
+          # Directory where Dockerfile is located.
+          # See: https://github.com/marketplace/actions/build-and-push-docker-images#git-context
+          context: "{{defaultContext}}:docker/loat-base-image"
+          # Overwrite the `latest` tag which is used to build the LoAT binaries:
+          # but also create tag the image with the current commit sha so old 
+          # images can still be accessed later:
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/loat-base:latest            
+            ${{ secrets.DOCKERHUB_USERNAME }}/loat-base:${{ github.sha }}

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,0 +1,88 @@
+name: Run Benchmarks
+
+# Run on push for every branch including pull requests from forked repositories.
+# And also allow this action to be triggered manually via a button in the GitHub UI.
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build-loat-binary:
+    runs-on: ubuntu-latest
+    steps:    
+      - name: Checkout LoAT Repository
+        uses: actions/checkout@v4
+        
+      - name: Build LoAT Binary
+        uses: addnab/docker-run-action@v3
+        with:
+          # Build LoAT binary inside the latest pushed base image:
+          image: "${{ vars.DOCKERHUB_USERNAME }}/loat-base:latest"
+          options: -v ${{ github.workspace }}:/LoAT
+          shell: bash
+          run: |
+            mkdir -p /LoAT/build/release
+            cd /LoAT/build/release
+            cmake -DCMAKE_BUILD_TYPE=Release ../../
+            make -j4
+
+      - name: Export LoAT Binary
+        uses: actions/upload-artifact@master
+        with:
+          name: loat-static
+          path: build/release/loat-static
+
+  chc-comp-benchmark:
+    needs: [build-loat-binary]
+    runs-on: ubuntu-latest
+    strategy: 
+      matrix: 
+        include:
+          - repo: 'chc-comp22-benchmarks'
+            directory: 'LIA-Lin'
+          - repo: 'chc-comp23-benchmarks'
+            directory: 'LIA-lin'
+    steps:
+      - name: Checkout Benchmark Repository
+        uses: actions/checkout@v4
+        with:
+          repository: chc-comp/${{ matrix.repo }}
+          sparse-checkout: ${{ matrix.directory }}
+
+      - name: Unpack
+        run: gunzip ${{ matrix.directory }}/*.gz
+
+      # retrieve previously built binary
+      - name: Import LoAT Binary
+        uses: actions/download-artifact@master
+        with:
+          name: loat-static
+          path: /usr/local/bin/
+     
+      - name: Run Benchmark
+        run: |
+          # permissions are not preserved for artifacts:
+          chmod +x /usr/local/bin/loat-static
+        
+          cd ${{ matrix.directory }}
+
+          for filename in *.smt2; do
+            printf "running ${filename} ... "
+            start=`date +%s`
+
+            set +e
+            result=$(timeout 20 loat-static --mode reachability --format horn --proof-level 0 --engine adcl "${filename}")
+            exit_status=$?
+            set -e
+
+            end=`date +%s`
+            runtime=$((end-start))
+
+            if [[ $exit_status -eq 0 ]]; then
+              result=$(echo "$result" | head -n 1)
+            elif [[ $exit_status -eq 124 ]]; then
+              result="timeout"
+            else
+              result="error"
+            fi
+
+            printf "${result} after ${runtime}s\n"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ benchmarks*
 .*
 !.vscode
 !.devcontainer
+!.github/
 
 # build stuff
 cmake-build-debug

--- a/docker/loat-base-image/Dockerfile
+++ b/docker/loat-base-image/Dockerfile
@@ -1,0 +1,305 @@
+# Getting OOM kills during builds on some systems (including in GitHub 
+# actions) if we don't limit the jobs for `make`. Default is set to 4.
+# To override this, run docker with the `--build-arg` flag. For example:
+#
+#     docker build --build-arg="JOBS=20"` .
+#
+# Notice that an additional `ARG JOBS` statement is required to use the
+# variable. For optimal caching it's better to put these statements right
+# before their use-site, because the cache for all subsequent build steps
+# is invalidated if the variable is changed.
+ARG JOBS=4
+
+FROM voidlinux/voidlinux-musl:latest as base
+
+ENV CFLAGS -march=x86-64 -O2
+ENV CXXFLAGS $CFLAGS
+RUN echo noextract=/etc/hosts > /etc/xbps.d/test.conf
+RUN echo "repository=https://repo-default.voidlinux.org/current/musl" > /etc/xbps.d/00-repository-main.conf
+RUN xbps-install -ySu xbps
+RUN xbps-install -ySu
+# Dependencies used by all (or most) subsequent build stages.
+# Note that changing these invalidaes the cache for all subsequent
+# build stages:
+RUN xbps-install -yS cmake make wget gcc autoconf bash git
+
+#######################################################
+
+FROM base as z3
+RUN xbps-install -yS python3-devel
+
+RUN wget https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.12.5.tar.gz
+RUN tar xf z3-4.12.5.tar.gz
+WORKDIR /z3-z3-4.12.5
+RUN mkdir build
+WORKDIR /z3-z3-4.12.5/build
+RUN cmake -DZ3_BUILD_LIBZ3_SHARED=FALSE -DCMAKE_BUILD_TYPE=Release ..
+ARG JOBS
+RUN make -j${JOBS}
+RUN make install
+
+#######################################################
+
+FROM base as z3-binary
+RUN xbps-install -yS python3-devel
+
+RUN wget https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.12.5.tar.gz
+RUN tar xf z3-4.12.5.tar.gz
+WORKDIR /z3-z3-4.12.5
+RUN python scripts/mk_make.py --staticbin
+WORKDIR /z3-z3-4.12.5/build
+ARG JOBS
+RUN make -j${JOBS}
+RUN make install
+
+#######################################################
+
+FROM base as ntl
+RUN xbps-install -yS gmp-devel
+
+RUN wget https://libntl.org/ntl-11.4.4.tar.gz
+RUN tar xf ntl-11.4.4.tar.gz
+WORKDIR /ntl-11.4.4/src
+RUN ./configure
+ARG JOBS
+RUN make -j${JOBS}
+RUN make install
+
+#######################################################
+
+FROM base as cudd
+RUN xbps-install -yS automake 
+
+RUN git clone https://github.com/ivmai/cudd.git
+WORKDIR /cudd
+# make check fails when compiled with -DNDEBUG
+RUN ./configure CFLAGS="$CFLAGS -fPIC" CXXFLAGS="$CXXFLAGS -fPIC"
+RUN sed -i 's/aclocal-1.14/aclocal-1.16/g' Makefile
+RUN sed -i 's/automake-1.14/automake-1.16/g' Makefile
+ARG JOBS
+RUN make -j${JOBS}
+RUN make -j${JOBS} check
+RUN make install
+
+#######################################################
+
+FROM base as poly
+RUN xbps-install -yS gmpxx-devel python-devel
+
+RUN wget https://github.com/SRI-CSL/libpoly/archive/refs/tags/v0.1.13.tar.gz
+RUN tar xf v0.1.13.tar.gz
+WORKDIR /libpoly-0.1.13/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
+ARG JOBS
+RUN make -j${JOBS}
+RUN make install
+
+#######################################################
+
+FROM base as cvc5
+RUN xbps-install -yS cln-devel git libtool python3-devel python3-pip texinfo
+
+RUN xbps-install -yS 
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip install tomli pyparsing
+
+COPY --from=poly /usr/local/lib/libpoly.a /usr/local/lib/
+COPY --from=poly /usr/local/lib/libpolyxx.a /usr/local/lib/
+COPY --from=poly /usr/local/include/poly /usr/local/include/poly
+
+RUN git clone https://github.com/ffrohn/cvc5
+WORKDIR cvc5
+RUN git checkout cvc5-1.0.8-musl
+RUN ./configure.sh --static --no-statistics --auto-download --poly --cln --gpl --no-docs
+WORKDIR /cvc5/build
+ARG JOBS
+RUN make -j${JOBS}
+RUN make install
+
+#######################################################
+
+FROM base as ginac
+RUN xbps-install -yS cln-devel python-devel
+
+RUN git clone git://www.ginac.de/ginac.git
+WORKDIR /ginac
+RUN git checkout release_1-8-7
+RUN mkdir build
+WORKDIR /ginac/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=false ..
+ARG JOBS
+RUN make -j${JOBS}
+RUN make install
+
+#######################################################
+
+FROM base as purrs
+RUN xbps-install -yS automake cln-devel gmpxx-devel libtool readline-devel
+
+COPY --from=ginac /usr/local/lib64/libginac.a /usr/local/lib64/libginac.a
+COPY --from=ginac /usr/local/include/ginac /usr/local/include/ginac
+
+COPY --from=ntl /usr/local/include/NTL /usr/local/include/NTL
+COPY --from=ntl /usr/local/lib/libntl.a /usr/local/lib/libntl.a
+
+RUN git clone https://github.com/aprove-developers/LoAT-purrs.git
+WORKDIR /LoAT-purrs
+RUN autoreconf --install
+RUN automake
+RUN ./configure
+ARG JOBS
+RUN make -j${JOBS}
+RUN make install
+
+#######################################################
+
+FROM base as swine
+RUN xbps-install -yS boost-devel
+
+COPY --from=z3 /usr/local/lib64/libz3.a /usr/local/lib64/
+COPY --from=z3 /usr/local/include/ /usr/local/include/
+
+RUN git clone https://github.com/ffrohn/swine-z3
+WORKDIR /swine-z3/scripts
+RUN ./configure_and_build.sh
+
+#######################################################
+
+FROM base as gmp
+RUN xbps-install -yS lzip
+
+RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN lzip -d gmp-6.2.1.tar.lz
+RUN tar xf gmp-6.2.1.tar
+WORKDIR /gmp-6.2.1
+RUN ./configure ABI=64 CFLAGS="$CFLAGS -fPIC" CPPFLAGS="$CXXFLAGS -DPIC" --host=x86_64-pc-linux-gnu --enable-cxx --prefix /gmp/
+ARG JOBS
+RUN make -j${JOBS}
+RUN make -j${JOBS} check
+RUN make install
+
+#######################################################
+
+FROM base as yices
+RUN xbps-install -yS gmp-devel gperf
+
+COPY --from=gmp /gmp /gmp
+
+COPY --from=poly /usr/local/lib/libpoly.a /usr/local/lib/
+COPY --from=poly /usr/local/include/poly /usr/local/include/poly
+
+COPY --from=cudd /usr/local/lib/libcudd.a /usr/local/lib/libcudd.a
+COPY --from=cudd /usr/local/include/cudd.h /usr/local/include/cudd.h
+
+RUN git clone https://github.com/SRI-CSL/yices2.git
+WORKDIR /yices2
+RUN autoconf
+RUN ./configure --enable-mcsat --with-pic-gmp=/gmp/lib/libgmp.a
+ARG JOBS
+RUN make -j${JOBS}
+RUN make -j${JOBS} static-lib
+RUN make install
+
+#######################################################
+
+FROM base as antlr4
+RUN xbps-install -yS git
+
+RUN git clone https://github.com/antlr/antlr4.git
+WORKDIR /antlr4
+RUN git checkout 4.11.1
+RUN mkdir /antlr4/runtime/Cpp/build
+WORKDIR /antlr4/runtime/Cpp/build
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR="/usr/local/lib"
+ARG JOBS
+RUN make -j${JOBS}
+RUN make install
+
+#######################################################
+
+FROM base as faudes
+RUN xbps-install -yS readline-devel
+
+# The following step keeps breaking because libfaudes developers don't keep
+# old archives around long after releasing new version. If it breaks go to
+# https://fgdes.tf.fau.de/download.html and check for a recent version. 
+# Then replace the value in the following env var:
+ENV VERSION=2_32a
+
+RUN wget https://fgdes.tf.fau.de/archive/libfaudes-${VERSION}.tar.gz
+RUN tar xf libfaudes-${VERSION}.tar.gz
+WORKDIR /libfaudes-${VERSION}
+RUN sed -i 's/MAINOPTS += -std=gnu++98 -D_GLIBCXX_USE_CXX11_ABI=0/MAINOPTS += -std=c++11/g' Makefile
+ARG JOBS
+RUN FAUDES_LINKING=static make -j${JOBS}
+RUN cp /libfaudes-${VERSION}/libfaudes.a /usr/local/lib/
+RUN cp -r /libfaudes-${VERSION}/include /usr/local/include/faudes
+
+#######################################################
+
+FROM alpine:3.18.4 as cln
+LABEL author="Florian Frohn"
+RUN apk add gcc g++ git automake autoconf make
+RUN apk add texinfo
+
+RUN git clone git://www.ginac.de/cln.git
+WORKDIR /cln
+RUN git checkout cln_1-3-6
+RUN ./autogen.sh
+RUN ./configure CXXFLAGS='-march=x86-64 -O3 -DNDEBUG' CFLAGS='-march=x86-64 -O3 -DNDEBUG'
+ARG JOBS
+RUN make -j${JOBS}
+RUN make install
+
+#######################################################
+
+# Final build stage that contains all dependencies to build LoAT itself
+FROM base as loat-base
+RUN xbps-install -yS gmp-devel boost-devel
+
+COPY --from=z3 /usr/local/lib64/libz3.a /usr/local/lib64/
+COPY --from=z3 /usr/local/include/z3*.h /usr/local/include/
+COPY --from=z3 /usr/local/bin/z3 /usr/local/bin/z3
+
+COPY --from=poly /usr/local/include/poly /usr/local/include/poly
+COPY --from=poly /usr/local/lib/libpoly.a /usr/local/lib/
+COPY --from=poly /usr/local/lib/libpolyxx.a /usr/local/lib/
+
+COPY --from=cudd /usr/local/include/cudd.h /usr/local/include/cudd.h
+COPY --from=cudd /usr/local/lib/libcudd.a /usr/local/lib/libcudd.a
+
+COPY --from=ntl /usr/local/include/NTL /usr/local/include/NTL
+COPY --from=ntl /usr/local/lib/libntl.a /usr/local/lib/libntl.a
+
+COPY --from=yices /usr/local/include/yices*.h /usr/local/include/
+COPY --from=yices /usr/local/lib/libyices.a /usr/local/lib/libyices.a
+
+COPY --from=ginac /usr/local/lib64/libginac.a /usr/local/lib64/libginac.a
+COPY --from=ginac /usr/local/include/ginac /usr/local/include/ginac
+
+COPY --from=purrs /usr/local/lib/libpurrs.a /usr/local/lib/libpurrs.a
+COPY --from=purrs /usr/local/include/purrs.hh /usr/local/include/purrs.hh
+
+COPY --from=antlr4 /usr/local/lib/libantlr4-runtime.a /usr/local/lib/libantlr4-runtime.a
+COPY --from=antlr4 /usr/local/include/antlr4-runtime/ /usr/local/include/
+
+COPY --from=faudes /usr/local/lib/libfaudes.a /usr/local/lib/libfaudes.a
+COPY --from=faudes /usr/local/include/faudes /usr/local/include/faudes
+
+COPY --from=cvc5 /usr/local/lib64/libcvc5.a /usr/local/lib/libcvc5.a
+COPY --from=cvc5 /usr/local/include/cvc5 /usr/local/include/cvc5
+COPY --from=cvc5 /usr/local/lib64/libcadical.a /usr/local/lib/libcadical.a
+
+COPY --from=swine /swine-z3/include/config.h /usr/local/include/swine/
+COPY --from=swine /swine-z3/include/lemma_kind.h /usr/local/include/swine/
+COPY --from=swine /swine-z3/include/preproc_kind.h /usr/local/include/swine/
+COPY --from=swine /swine-z3/include/swine.h /usr/local/include/swine/
+COPY --from=swine /swine-z3/build/libswine-z3.a /usr/local/lib/
+
+COPY --from=cln /usr/local/lib/libcln.a /usr/local/lib/
+COPY --from=cln /usr/local/include/cln /usr/local/include/cln
+
+COPY --from=ntl /usr/local/lib/libntl.a /usr/local/lib/
+COPY --from=ntl /usr/local/include/NTL /usr/local/include/NTL


### PR DESCRIPTION
Since running all benchmarks takes so long, it's easy to miss regressions or progressions due to changes. Then later when they are spotted, it can be time consuming to figure out which change was responsible. By setting up a GitHub action, that runs on every pushed commit we get full benchmark results that are always associated with a change.

Running the benchmarks requires building the LoAT binary, and that in turn requires building all the dependencies (z3, yices, etc.) which takes very long and is very fragile. Presumably, the dependencies don't change that often though and don't actually depend on the sources in the LoAT repo. Thus, it makes sense to prepare a base docker image with all dependencies that is only re-build when needed. The setup looks as follows:

 * the Dockerfile in `docker/loat-base-image/` describes all dependencies but does not build LoAT itself.
 * a dedicated GitHub action (`.github/workflows/build-base-image.yml`) that automatically runs iff changes in `docker/loat-base-image/` are pushed to `master` (can also be triggered manually)
 * the action builds the image and pushes it to Docker Hub.

With the base image on Docker Hub, the benchmark action can just pull it and build the LoAT binary inside it. The base images can also be used locally, so it's not/less necessary to wait for these slow builds to complete locally. The base images are also tagged with a commit SHA. So older base images are still accessible. That's particularly useful when working on a branch where the dependencies older/newer compared to `master`. It's very annoying when all the dependencies have to be re-build just when switching between `master` and feature branch.

To describe all dependendencies together I put everything back into a single Dockerfile (sorry).

The benchmark action runs on every push to every branch including pull requests from external forks. At the moment it runs on the LIA-Lin benchmark for CHC comp 22 and 23. As a nice side effect is that the built LoAT binary of each run can be downloaded through the GitHub UI. Here is [an example run on my fork](https://github.com/gruhn/LoAT/actions/runs/8133333011). 

There are plenty of things that could be improved. For example, at the moment only the current result of the solver is printed. It's not compared with previous runs or other solvers. Once this is setup, one could also let he job fail if regressions or conflicts are detected. But for now, I think this setup is very useful already.

Only thing left to do, is configure Docker Hub credentials for this repository. Go to `Settings` -> `Secrets and variables` (in the sidebar) -> `Actions`. Then
 * Create a `New repository secret` with name `DOCKERHUB_TOKEN`. You can get the token from [Docker Hub](https://hub.docker.com) under `My Account` -> `Security` -> `New Access Token`
 * Create a `New repository variable` with name `DOCKERHUB_USERNAME` and your username. This is *not a secret* because the GitHub action needs unencrypted access to this variable. All pushed docker images are prefixed with the username (e.g. `docker pull <USERNAME>/loat-base:latest`).